### PR TITLE
Tests for #20

### DIFF
--- a/test/selectall_write_stream.html
+++ b/test/selectall_write_stream.html
@@ -1,0 +1,3 @@
+<a href="foo"></a>
+<a href="bar"></a>
+<a href="foo"></a>

--- a/test/selectall_write_stream.js
+++ b/test/selectall_write_stream.js
@@ -1,0 +1,58 @@
+var trumpet = require('../');
+var fs = require('fs');
+var test = require('tape');
+var concat = require('concat-stream');
+
+test('.selectAll() write stream opened before .getAttribute()', function (t) {
+    t.plan(1);
+    
+    var tr = trumpet();
+    
+    tr.pipe(concat(function (body) {
+        t.equal(
+            body.toString(),
+            '<a href="foo">foo</a>\n<a href="bar"></a>\n<a href="foo">foo</a>\n'
+        );
+    }));
+    
+    tr.selectAll('a[href]', function(node) {
+        var out = node.createWriteStream();
+        
+        node.getAttribute('href', function(href) {
+            if(href !== 'foo') {
+                out.end();
+                
+                return;
+            }
+            
+            out.end(href);
+        });
+    });
+    
+    fs.createReadStream(__dirname + '/selectall_write_stream.html').pipe(tr);
+});
+
+test('.selectAll() write stream opened inside .getAttribute()', function (t) {
+    t.plan(1);
+    
+    var tr = trumpet();
+    
+    tr.pipe(concat(function (body) {
+        t.equal(
+            body.toString(),
+            '<a href="foo">foo</a>\n<a href="bar"></a>\n<a href="foo">foo</a>\n'
+        );
+    }));
+    
+    tr.selectAll('a[href]', function(node) {
+        node.getAttribute('href', function(href) {
+            if(href !== 'foo') {
+                return;
+            }
+            
+            node.createWriteStream().end(href);
+        });
+    });
+    
+    fs.createReadStream(__dirname + '/selectall_write_stream.html').pipe(tr);
+});


### PR DESCRIPTION
This seemed more useful for debugging #20 than just pasting in more code. Sorry it took me a bit.

Works fine if you open the writeStream before the `.getAttribute()` call. Opening stream inside `.getAttribute()` pauses the entire program to end.

Haven't been able to figure out why yet.