### PR TITLE
Fix duplex stream handling on _end

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ Trumpet.prototype._selectAll = function (str, cb) {
         });
         
         duplex.splice(0).forEach(function (d) {
-            d.end();
-            d.resume();
+            d.input.end();
+            d.input.resume();
         });
     });
     


### PR DESCRIPTION
`duplex` array consists of objects with `input`, `output` and `options` properties, not actual streams. Hence calling `end` method is incorrect:

```
duplex.splice(0).forEach(function (d) {
  d.end();
  d.resume();
});
```

Run-time error:

```
TypeError: Object #<Object> has no method 'end'
```

This patch fixes it by closing input side of a duplex. I believe this is what this code was meant to do.

This issue causes crashes in beefy: chrisdickinson/beefy#75

Close #56.