### PR TITLE
changed require to duplexer2

### DIFF
--- a/example/inline_coffee.js
+++ b/example/inline_coffee.js
@@ -1,7 +1,7 @@
 var trumpet = require('../');
 var fs = require('fs');
 var through = require('through');
-var duplexer = require('duplexer');
+var duplexer = require('duplexer2');
 var concat = require('concat-stream');
 var coffee = require('coffee-script');
 


### PR DESCRIPTION
Module duplexer is not included in this package. Changed require('duplexer') to require('duplexer2').